### PR TITLE
Fix showing status of new branch without previous builds

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,9 +101,10 @@
       function createBranch(branch, branchName) {
         function createListItem() {
           var buildIsRunning = branch.running_builds.length != 0
-          var status = buildIsRunning ? branch.running_builds[0].status : branch.recent_builds[0].outcome
+          var build = buildIsRunning ? branch.running_builds[0] : branch.recent_builds[0]
+          var status = buildIsRunning ? build.status : build.outcome
           var name = `${project}: ${decodeURIComponent(branchName)}`
-          var time = new Date(branch.recent_builds[0].pushed_at)
+          var time = new Date(build.pushed_at)
 
           var newNode = document.createElement('li')
           var header = document.createElement('h1')


### PR DESCRIPTION
[Line 106](https://github.com/sampsakuronen/circleci-radiator-view/blob/f40e299e72de221b0d8ca78c41f9b8c0909df3ab/index.html#L106) threw an error because `branch.recent_builds` was an empty list.

Now shows `pushed_at` of the running build instead of the latest completed build.
