### PR TITLE
Show up to 25 builds in columns of five

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -94,9 +94,11 @@
   }
 
   @media (min-width: 410px) {
-    .fill-height-or-more > li {
-      max-width: calc(50%);
-    }
+    .split-1 > li { max-width: calc(100% / 1); }
+    .split-2 > li { max-width: calc(100% / 2); }
+    .split-3 > li { max-width: calc(100% / 3); }
+    .split-4 > li { max-width: calc(100% / 4); }
+    .split-5 > li { max-width: calc(100% / 5); }
   }
 </style>
 <body>
@@ -151,7 +153,18 @@
       _.map(repository.branches, createBranch)
     }
 
+    function calculateColumns(data) {
+      const builds = _.sumBy(data, repo => Object.keys(repo.branches).length)
+      return Math.min(5, Math.ceil(builds / 5))
+    }
+
+    function setRadiatorColumns(columns) {
+      radiator.classList.remove([1, 2, 3, 4, 5].map(n => 'split-' + n))
+      radiator.classList.add('split-' + columns)
+    }
+
     function createJobList(data) {
+      setRadiatorColumns(calculateColumns(data))
       radiator.innerHTML = ''
       radiator.style.display = 'flex'
 


### PR DESCRIPTION
Previously builds after the first ten were out of browser viewport.

New attempt. I totally missed the fact CircleCI doesn't return a list of branches but a list of repos that contain branches.