### PR TITLE
Feature/travis owner name filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# Simple build status radiator view
+# Simple build status and alarm radiator view
 
 Many continuous integration services lack a nice and simple radiator view / dashboard.
 This project simply displays all your projects and selected branches with status based coloring.
 
-Supported backends are [CircleCI](https://circleci.com/), [Travis CI](https://travis-ci.org/) and
-[Jenkins](https://jenkins.io).
+Production (or any other) environment monitoring is another good practice. Radiate your alarms as well as builds!
+
+Supported CI backends are [CircleCI](https://circleci.com/), [Travis CI](https://travis-ci.org/), [Jenkins](https://jenkins.io).
+
+For alarm monitoring, [AWS CloudWatch Alarms](https://aws.amazon.com) is supported.
 
 ![Circle CI Radiator view](/readme_radiator.png?raw=true "Circle CI Radiator view")
 
@@ -15,17 +18,27 @@ Supported backends are [CircleCI](https://circleci.com/), [Travis CI](https://tr
 
 1. Get your API token from [your CirleCI account settings](https://circleci.com/account/api)
 2. Open `index.html`
-
+3. Add your token to the token field
 
 ## Setup for Travis CI
 
 1. Get your API token from (https://travis-ci.org/profile/<your_profile>)
 2. Open `index.html?mode=travis`
+3. Add your token to the token field
 
 ## Setup for Jenkins
 
 1. Create a user and a token for the user in your job settings
-2. Open `index.html?mode=jenkins` and add the job end point URL (eg. http://host/jenkins/job/My%20Job)
+2. Open `index.html?mode=jenkins` and
+  * Add the job end point URL (eg. http://host/jenkins/job/My%20Job)
+  * Set the user name and the generated token in the token field, separated by a colon, ie. *userid:thetokenhash*.
+
+## Setup for AWS CloudWatch
+
+1. Create a monitor user with read-only access in IAM
+2. Open `index.html?mode=cloudwatch` and
+  * Modify the URL to contain the proper region (defaults to eu-west-1)
+  * Set the access key and secret key as token, separated by a colon, ie. *ACCESSKEY:longsecretkey*.
 
 ## Query parameters
 
@@ -41,6 +54,8 @@ any required parameters are missing.
    Select the branch to show (from all repos found in the API end point).
    Useful if your repos contain only a single branch (master, release etc) that should be visible
    in the radiator view.
+
+   The branch is understood as a regular expression, so you can say something like _master|PR.*_
 
 - token
 
@@ -64,12 +79,12 @@ Example where the token is entered in an input field:
 
 Jenkins example:
 
-   https://yourdomain.com/?mode=jenkins&token=jenkins_token&url=http://localhost:8080/jenkins/job/My%20Job
+   https://yourdomain.com/?mode=jenkins&token=user:jenkins_token&branch=master|PR.*&url=http://localhost:8080/jenkins/job/My%20Job
 
 
 ## Hosted version
 
-Available here: https://sampsakuronen.github.io/circleci-radiator-view/
+Available here: https://sampsakuronen.github.io/circleci-radiator-view/ or here: https://langma.github.io/radiator-view/
 
 
 ## Licence

--- a/docs/backends.js
+++ b/docs/backends.js
@@ -127,17 +127,21 @@ var travisBackend = function(settings, resultCallback) {
    var parseBuilds = function(repos) {
       var responses = []
       repos.forEach(function(r) {
-         travisRequest(settings.url + '/' + r.name + '/builds', function(data) {
-            var reponame = r.name.split('/')[1]
-            var builds = data.builds.map(translateBuild(reponame, data.commits))
-            responses.push(builds)
-            if (responses.length === repos.length) {
-               var result = responses.reduce(function(acc, item) {
-                  return item.length > 0 ? acc.concat(item) : acc
-               }, [])
-               resultCallback(undefined, result)
-            }
-         })
+         // NOTE: Temporary hack to only get kuha-tnx repositories
+         var organizationName = r.name.split('/')[0];
+         if (organizationName === "kuha-tnx") {
+            travisRequest(settings.url + '/' + r.name + '/builds', function(data) {
+               var reponame = r.name.split('/')[1]
+               var builds = data.builds.map(translateBuild(reponame, data.commits))
+               responses.push(builds)
+               if (responses.length === repos.length) {
+                  var result = responses.reduce(function(acc, item) {
+                     return item.length > 0 ? acc.concat(item) : acc
+                  }, [])
+                  resultCallback(undefined, result)
+               }
+            })
+         }
       })
    }
 

--- a/docs/backends.js
+++ b/docs/backends.js
@@ -127,21 +127,17 @@ var travisBackend = function(settings, resultCallback) {
    var parseBuilds = function(repos) {
       var responses = []
       repos.forEach(function(r) {
-         // NOTE: Temporary hack to only get kuha-tnx repositories
-         var organizationName = r.name.split('/')[0];
-         if (organizationName === "kuha-tnx") {
-            travisRequest(settings.url + '/' + r.name + '/builds', function(data) {
-               var reponame = r.name.split('/')[1]
-               var builds = data.builds.map(translateBuild(reponame, data.commits))
-               responses.push(builds)
-               if (responses.length === repos.length) {
-                  var result = responses.reduce(function(acc, item) {
-                     return item.length > 0 ? acc.concat(item) : acc
-                  }, [])
-                  resultCallback(undefined, result)
-               }
-            })
-         }
+         travisRequest(settings.url + '/' + r.name + '/builds', function(data) {
+            var reponame = r.name.split('/')[1]
+            var builds = data.builds.map(translateBuild(reponame, data.commits))
+            responses.push(builds)
+            if (responses.length === repos.length) {
+               var result = responses.reduce(function(acc, item) {
+                  return item.length > 0 ? acc.concat(item) : acc
+               }, [])
+               resultCallback(undefined, result)
+            }
+         })
       })
    }
 

--- a/docs/backends.js
+++ b/docs/backends.js
@@ -43,21 +43,26 @@ function backendOptions() {
       'circle': {
          name: 'Circle CI',
          url: 'https://circleci.com/api/v1/projects',
+         supportsOwnernameFiltering: false,
          token: undefined
       },
       'travis': {
          name: 'Travis CI',
          url: 'https://api.travis-ci.com/repos',
+         supportsOwnernameFiltering: true,
+         ownername: '',
          token: undefined
       },
       'jenkins': {
          name: 'Jenkins CI',
          url: undefined,
+         supportsOwnernameFiltering: false,
          token: undefined
       },
       'cloudwatch': {
          name: 'AWS CloudWatch',
          url: 'https://monitoring.eu-west-1.amazonaws.com/',
+         supportsOwnernameFiltering: false,
          token: undefined
       }
    }
@@ -141,7 +146,8 @@ var travisBackend = function(settings, resultCallback) {
       })
    }
 
-   travisRequest(settings.url, function(data) {
+   var reposUrl = settings.url + (settings.ownername ? '?owner_name=' + settings.ownername : '');
+   travisRequest(reposUrl, function(data) {
       parseBuilds(data.repos.map(function(repo) {return {id: repo.id, name: repo.slug}}))
    })
 }

--- a/docs/backends.js
+++ b/docs/backends.js
@@ -303,7 +303,7 @@ var cloudWatchBackend = function(settings, resultCallback) {
          return {
             repository: alarm.AlarmName,
             started: alarm.StateUpdatedTimestamp,
-            state: alarm.StateValue === 'OK' ? 'success' : 'failed'
+            state: result
          }
       })
       resultCallback(undefined, builds)

--- a/docs/backends.js
+++ b/docs/backends.js
@@ -19,6 +19,8 @@ function buildBackend(settings, callback) {
       backend = travisBackend
    } else if (settings.mode === 'jenkins') {
       backend = jenkinsBackend
+   } else if (settings.mode === 'cloudwatch') {
+      backend = cloudWatchBackend
    }
    var branchFilter = function(build) {
       return settings.branch ? build.branch.match(settings.branch) : true
@@ -42,7 +44,6 @@ function backendOptions() {
          name: 'Circle CI',
          url: 'https://circleci.com/api/v1/projects',
          token: undefined
-
       },
       'travis': {
          name: 'Travis CI',
@@ -52,6 +53,11 @@ function backendOptions() {
       'jenkins': {
          name: 'Jenkins CI',
          url: undefined,
+         token: undefined
+      },
+      'cloudwatch': {
+         name: 'AWS CloudWatch',
+         url: 'https://monitoring.eu-west-1.amazonaws.com/',
          token: undefined
       }
    }
@@ -86,10 +92,9 @@ var travisBackend = function(settings, resultCallback) {
    var travisRequest = function(url, cb) {
       var handler = function(err, data) {
          if (err) {
-            resultCallback(err)
-         } else {
-            cb(data)
+            return resultCallback(err)
          }
+         cb(data)
       }
       httpRequest(url, handler, {
          Accept: 'application/vnd.travis-ci.2+json',
@@ -177,10 +182,9 @@ var jenkinsBackend = function(settings, resultCallback) {
    var jenkinsRequest = function(url, cb) {
       var handler = function(err, data) {
          if (err) {
-            resultCallback(err)
-         } else {
-            cb(data)
+            return resultCallback(err)
          }
+         cb(data)
       }
       var headers = {}
       if (settings.token) {
@@ -272,6 +276,36 @@ var jenkinsBackend = function(settings, resultCallback) {
                })
          }, []))
       }, [])
+      resultCallback(undefined, builds)
+   })
+}
+
+var cloudWatchBackend = function(settings, resultCallback) {
+   var creds = settings.token.split(':')
+   var region = settings.url.split('.')[1]
+   var cloudwatch = new AWS.CloudWatch({
+      accessKeyId: creds[0],
+      secretAccessKey: creds[1],
+      region: region,
+   })
+   var params = {}
+   cloudwatch.describeAlarms(params, function(err, data) {
+      if (err) {
+         return resultCallback(err)
+      }
+      var builds = data.MetricAlarms.map(function(alarm) {
+         var result = 'canceled'
+         if (alarm.StateValue === 'OK') {
+            result = 'success'
+         } else if (alarm.StateValue === 'ALARM') {
+            result = 'failed'
+         }
+         return {
+            repository: alarm.AlarmName,
+            started: alarm.StateUpdatedTimestamp,
+            state: alarm.StateValue === 'OK' ? 'success' : 'failed'
+         }
+      })
       resultCallback(undefined, builds)
    })
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -131,6 +131,9 @@
     .split-5 > li { max-width: calc(100% / 5); }
     .split-6 > li { max-width: calc(100% / 6); }
     .split-7 > li { max-width: calc(100% / 7); }
+    .split-8 > li { max-width: calc(100% / 8); }
+    .split-9 > li { max-width: calc(100% / 9); }
+    .split-10 > li { max-width: calc(100% / 10); }
   }
 </style>
 <body>
@@ -188,7 +191,7 @@
     }
 
     function setRadiatorColumns(columns) {
-      radiator.classList.remove.apply(radiator.classList, [1, 2, 3, 4, 5, 6, 7].map(n => 'split-' + n))
+      radiator.classList.remove.apply(radiator.classList, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(n => 'split-' + n))
       radiator.classList.add('split-' + columns)
     }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -59,7 +59,7 @@
   }
 
   .fill-height-or-more > li {
-    flex: 1 0 20%;
+    flex: 1 0 10%;
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,7 @@
   <meta name="mobile-web-app-capable" content="yes" />
   <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.min.js"></script>
+  <script src="https://sdk.amazonaws.com/js/aws-sdk-2.45.0.min.js"></script>
   <script src="backends.js"></script>
 </head>
 <style>

--- a/docs/index.html
+++ b/docs/index.html
@@ -194,6 +194,7 @@
       setRadiatorColumns(calculateColumns(builds))
       radiator.innerHTML = ''
       radiator.style.display = 'flex'
+      error.style.display = 'none'
 
       _.map(builds, createJob)
    }

--- a/docs/index.html
+++ b/docs/index.html
@@ -80,6 +80,10 @@
     text-align: center;
   }
 
+  #ownername {
+    display: none;
+  }
+
   .settings-form {
     display: none;
     align-items: center;
@@ -141,6 +145,7 @@
     <h1>Configure API endpoint</h1>
     <select id="mode"></select>
     <input type="text" id="serverurl" placeholder="API base URL" autofocus></input>
+    <input type="text" id="ownername" placeholder="Owner name filter"></input>
     <input type="password" id="apitoken" placeholder="API token"></input>
     <input type="submit" value="Begin" id="submit"></input>
   </div>
@@ -232,6 +237,8 @@
       var opt = opts[settings.mode]
       settings.url = opt.url || settings.url
       settings.token = opt.token || settings.token
+      settings.supportsOwnernameFiltering = opt.supportsOwnernameFiltering;
+      settings.ownername = opt.ownername || settings.ownername
       return settings
     }
 
@@ -249,6 +256,7 @@
       var modeSelect = document.getElementById('mode')
       var serverUrlInput = document.getElementById('serverurl')
       var apiTokenInput = document.getElementById('apitoken')
+      var ownernameInput = document.getElementById('ownername')
       var submit = document.getElementById('submit')
       settingsForm.style.display = 'block'
 
@@ -267,6 +275,8 @@
         settings = extendWithDefaults(settings)
         serverUrlInput.value = settings.url
         apiTokenInput.value = settings.token
+        ownernameInput.value = settings.ownername
+        ownernameInput.style.display = settings.supportsOwnernameFiltering ? 'block' : 'none'
       }
       setUISelections(settings.mode || defaults[_.keys(defaults)[0]].mode)
 
@@ -278,6 +288,7 @@
         settingsForm.style.display = 'none'
         settings.url = serverUrlInput.value
         settings.token = apiTokenInput.value
+        settings.ownername = ownernameInput.value
         start(settings)
       })
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -85,7 +85,6 @@
     justify-content: left;
     height: inherit;
     margin: 0% 10% 0% 10%;
-
   }
 
   .settings-form input[type=text],
@@ -132,12 +131,12 @@
   }
 </style>
 <body>
-    <div class="settings-form">
-        <h1>Configure API endpoint</h1>
-        <select id="mode"></select>
-        <input type="text" id="serverurl" placeholder="API base URL" autofocus></input>
-        <input type="password" id="apitoken" placeholder="API token"></input>
-        <input type="submit" value="Begin" id="submit"></input>
+  <div class="settings-form">
+    <h1>Configure API endpoint</h1>
+    <select id="mode"></select>
+    <input type="text" id="serverurl" placeholder="API base URL" autofocus></input>
+    <input type="password" id="apitoken" placeholder="API token"></input>
+    <input type="submit" value="Begin" id="submit"></input>
   </div>
 
   <ul id="radiator" class="fill-height-or-more">
@@ -145,14 +144,17 @@
   <h1 id="error"></h1>
 
   <script>
-   var updateInterval = 20 * 1000
-   var settings
+    var updateInterval = 20 * 1000
+    var settings
 
-   var radiator = document.getElementById('radiator')
-   var error = document.getElementById('error')
+    var radiator = document.getElementById('radiator')
+    var error = document.getElementById('error')
 
-   function createJob(build) {
-      var name = `${build.repository}: ${decodeURIComponent(build.branch)}`
+    function createJob(build) {
+      var name = build.repository
+      if (build.branch) {
+        name = `${build.repository}: ${decodeURIComponent(build.branch)}`
+      }
       var time = new Date(build.started)
 
       var listItem = document.createElement('li')
@@ -161,35 +163,35 @@
       var author = document.createElement('div')
       var authorName = ''
       if (build.commit && build.commit.author) {
-           authorName = build.commit.author
+        authorName = build.commit.author
       }
 
       header.textContent = name
       description.textContent = `
-      ${time.getDate()}.${time.getMonth() + 1}.${time.getFullYear()}
-      ${time.toString().replace(/.*(\d{2}:\d{2}):(\d{2}).*/, '$1')}
-      `
+        ${time.getDate()}.${time.getMonth() + 1}.${time.getFullYear()}
+        ${time.toString().replace(/.*(\d{2}:\d{2}):(\d{2}).*/, '$1')}
+        `
       author.innerHTML = authorName
 
       listItem.innerHTML = header.outerHTML + description.outerHTML + author.outerHTML
       listItem.className = build.state
 
       radiator.innerHTML = radiator.innerHTML + listItem.outerHTML
-   }
+    }
 
-   function calculateColumns(data) {
+    function calculateColumns(data) {
       var builds = data.length
       return Math.min(5, Math.ceil(builds / 5))
-   }
+    }
 
-   function setRadiatorColumns(columns) {
+    function setRadiatorColumns(columns) {
       radiator.classList.remove.apply(radiator.classList, [1, 2, 3, 4, 5, 6].map(n => 'split-' + n))
       radiator.classList.add('split-' + columns)
-   }
+    }
 
-   function createJobList(err, builds) {
+    function createJobList(err, builds) {
       if (err) {
-         return displayError(err)
+        return displayError(err)
       }
       setRadiatorColumns(calculateColumns(builds))
       radiator.innerHTML = ''
@@ -197,46 +199,46 @@
       error.style.display = 'none'
 
       _.map(builds, createJob)
-   }
+    }
 
-   function displayError(message) {
+    function displayError(message) {
       radiator.style.display = 'none'
       radiator.innerHTML = ''
       error.textContent = message
       error.style.display = 'block'
       console.log(message)
-   }
+    }
 
-   function start(settings) {
+    function start(settings) {
       var backend = buildBackend(settings, createJobList) || displayError('Invalid backend ' + settings.mode)
       setInterval(backend, updateInterval)
       backend()
       setInterval(function(){location.reload(true)}, 24 * 60 * 60 * 1000)
-   }
+    }
 
-   function extendWithDefaults(settings) {
+    function extendWithDefaults(settings) {
       var opts = backendOptions()
       var mode = settings.mode
       if (!opts[mode]) {
-         mode = _.keys(opts)[0]
-         settings.mode = mode
+        mode = _.keys(opts)[0]
+        settings.mode = mode
       }
       var opt = opts[settings.mode]
       settings.url = opt.url || settings.url
       settings.token = opt.token || settings.token
       return settings
-   }
+    }
 
-   var query = window.location.search.substring(1)
-   var settings = _.chain(query.split('&')).map(function(params) {
+    var query = window.location.search.substring(1)
+    var settings = _.chain(query.split('&')).map(function(params) {
       var p = params.split('=')
       return [p[0], decodeURIComponent(p[1])]
-   }).fromPairs().value()
-   settings = extendWithDefaults(settings)
+    }).fromPairs().value()
+    settings = extendWithDefaults(settings)
 
-   if (settings && settings.mode && settings.url && settings.token) {
+    if (settings && settings.mode && settings.url && settings.token) {
       start(settings)
-   } else {
+    } else {
       var settingsForm = document.querySelector('.settings-form')
       var modeSelect = document.getElementById('mode')
       var serverUrlInput = document.getElementById('serverurl')
@@ -246,32 +248,32 @@
 
       var defaults = backendOptions()
       Object.keys(defaults).forEach(function(option) {
-         var o = document.createElement("option")
-         o.text = defaults[option].name
-         o.value = option
-         if (settings.mode == option) {
-            o.selected = true
-         }
-         modeSelect.add(o)
+        var o = document.createElement("option")
+        o.text = defaults[option].name
+        o.value = option
+        if (settings.mode == option) {
+          o.selected = true
+        }
+        modeSelect.add(o)
       })
       var setUISelections = function(mode) {
-         settings.mode = mode || settings.mode
-         settings = extendWithDefaults(settings)
-         serverUrlInput.value = settings.url
-         apiTokenInput.value = settings.token
+        settings.mode = mode || settings.mode
+        settings = extendWithDefaults(settings)
+        serverUrlInput.value = settings.url
+        apiTokenInput.value = settings.token
       }
       setUISelections(settings.mode || defaults[_.keys(defaults)[0]].mode)
 
       modeSelect.addEventListener('change', function(e) {
-         settings.mode = modeSelect.options[modeSelect.selectedIndex].value
-         setUISelections()
+        settings.mode = modeSelect.options[modeSelect.selectedIndex].value
+        setUISelections()
       })
       submit.addEventListener('click', function() {
-         settingsForm.style.display = 'none'
-         settings.url = serverUrlInput.value
-         settings.token = apiTokenInput.value
-         start(settings)
+        settingsForm.style.display = 'none'
+        settings.url = serverUrlInput.value
+        settings.token = apiTokenInput.value
+        start(settings)
       })
-   }
+    }
   </script>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -129,6 +129,8 @@
     .split-3 > li { max-width: calc(100% / 3); }
     .split-4 > li { max-width: calc(100% / 4); }
     .split-5 > li { max-width: calc(100% / 5); }
+    .split-6 > li { max-width: calc(100% / 6); }
+    .split-7 > li { max-width: calc(100% / 7); }
   }
 </style>
 <body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -59,7 +59,7 @@
   }
 
   .fill-height-or-more > li {
-    flex: 1 0 10%;
+    flex: 1 0 20%;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -184,11 +184,11 @@
 
     function calculateColumns(data) {
       var builds = data.length
-      return Math.min(5, Math.ceil(builds / 5))
+      return Math.ceil(builds / 5)
     }
 
     function setRadiatorColumns(columns) {
-      radiator.classList.remove.apply(radiator.classList, [1, 2, 3, 4, 5, 6].map(n => 'split-' + n))
+      radiator.classList.remove.apply(radiator.classList, [1, 2, 3, 4, 5, 6, 7].map(n => 'split-' + n))
       radiator.classList.add('split-' + columns)
     }
 


### PR DESCRIPTION
# Reason

Travis API has started to return a bunch of public repositories in addition to our own repos. The API supports filtering by repo owner, so that can be used to receive only our repos.

# Implementation

The radiator now supports parameter `ownername`. It can be given in URL like this: https://kuha-tnx.github.io/radiator-view/docs/index.html?mode=travis&branch=master&token=TOKEN&ownername=kuha-tnx

Additionally added the new owner filter as a form field to UI, if radiator is started without query parameters. Currently this is shown only if selected mode is Travis. For other CI options the form field is not shown. This is configurable separately for each CI mode.

# Verification

Ran locally index.html with query parameters & by using the UI.