### PR TITLE
Newest builds first

### DIFF
--- a/docs/backends.js
+++ b/docs/backends.js
@@ -39,7 +39,7 @@ function buildBackend(settings, callback) {
         return b.repository + b.branch
       })
       builds = builds.sort(function(a, b) {
-        return a.started.getTime() - b.started.getTime()
+        return b.started.getTime() - a.started.getTime()
       })
       callback(undefined, builds)
     })


### PR DESCRIPTION
Changed the sort order of the builds so that the builds of newest branches are first instead of last.

For people who have many branches, there is not enough room on the radiator to fit all the builds without having to scroll. When the builds are ordered with the newest builds last, they do not appear on the page. By changing the order so that the newest builds are first, they will always appear on the page.